### PR TITLE
Removed certbot references from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,10 @@ FROM node:boron
 
 WORKDIR /usr/src/app
 
-RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list		
-
-RUN apt-get -y update		
-RUN apt-get -y -t jessie-backports install certbot python-certbot
+RUN apt-get -y update && apt -y upgrade
 
 COPY package.json /usr/src/app/
+
 RUN cd /usr/src/app && \
     echo "Installing dependancies, this may take a while" && \
     npm install


### PR DESCRIPTION
Removed certbot references from Dockerfile.
This is handled in vhs/docker-vhs-nginx now.